### PR TITLE
Service Attribute Interface Specification

### DIFF
--- a/DJT.Vertical/Attributes/ScopedServiceAttribute.cs
+++ b/DJT.Vertical/Attributes/ScopedServiceAttribute.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace DJT.Vertical.Attributes
+﻿namespace DJT.Vertical.Attributes
 {
     /// <summary>
     /// Register the class with the DI as a scoped service,

--- a/DJT.Vertical/Attributes/ScopedServiceAttribute.cs
+++ b/DJT.Vertical/Attributes/ScopedServiceAttribute.cs
@@ -14,6 +14,27 @@ namespace DJT.Vertical.Attributes
     public class ScopedServiceAttribute : Attribute
     {
         /// <summary>
+        /// Register the class as a scoped service
+        /// </summary>
+        public ScopedServiceAttribute() { }
+
+        /// <summary>
+        /// Register the class as a scoped service which implements type <see cref="ImplementsType"/>
+        /// </summary>
+        /// <param name="implements">The type which the decorated class implements</param>
+        /// <param name="key">The keyed type</param>
+        public ScopedServiceAttribute(Type implements, string key = "")
+        {
+            ImplementsType = implements;
+            Key = key;
+        }
+
+        /// <summary>
+        /// The type (typically interface) which this scoped service implements
+        /// </summary>
+        public Type? ImplementsType { get; set; }
+
+        /// <summary>
         /// If supplied, the service will be registered as a keyed service
         /// </summary>
         public string Key { get; set; } = string.Empty;

--- a/DJT.Vertical/Attributes/SingletonServiceAttribute.cs
+++ b/DJT.Vertical/Attributes/SingletonServiceAttribute.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace DJT.Vertical.Attributes
+﻿namespace DJT.Vertical.Attributes
 {
     /// <summary>
     /// Register the class with the DI as a singleton service,

--- a/DJT.Vertical/Attributes/SingletonServiceAttribute.cs
+++ b/DJT.Vertical/Attributes/SingletonServiceAttribute.cs
@@ -14,6 +14,29 @@ namespace DJT.Vertical.Attributes
     public class SingletonServiceAttribute : Attribute
     {
         /// <summary>
+        /// Registers the class as a singleton service.
+        /// </summary>
+        public SingletonServiceAttribute() { }
+
+        /// <summary>
+        /// Imeplements the decorated class as an singleton implementation of
+        /// <see cref="ImplementsType"/>.  If the key is set, it will be a keyed
+        /// service.
+        /// </summary>
+        /// <param name="implements"></param>
+        /// <param name="key"></param>
+        public SingletonServiceAttribute(Type implements, string key = "")
+        {
+            ImplementsType = implements;
+            Key = key;
+        }
+
+        /// <summary>
+        /// The type (typically interface) which this scoped service implements
+        /// </summary>
+        public Type? ImplementsType { get; set; }
+
+        /// <summary>
         /// If supplied, the service will be registered as a keyed service
         /// </summary>
         public string Key { get; set; } = string.Empty;

--- a/DJT.Vertical/Attributes/TransientServiceAttribute.cs
+++ b/DJT.Vertical/Attributes/TransientServiceAttribute.cs
@@ -14,6 +14,30 @@ namespace DJT.Vertical.Attributes
     public class TransientServiceAttribute : Attribute
     {
         /// <summary>
+        /// Registers the decorated class with the DI container as
+        /// a transient service.
+        /// </summary>
+        public TransientServiceAttribute() { }
+
+        /// <summary>
+        /// Registers the decorated class as a transient service
+        /// which implements the given type <see cref="ImplementsType"/>
+        /// and with the given key if included.
+        /// </summary>
+        /// <param name="implements">The type the class implements.</param>
+        /// <param name="key">If provided, the keyed service</param>
+        public TransientServiceAttribute(Type implements, string key = "")
+        {
+            ImplementsType = implements;
+            Key = key;
+        }
+
+        /// <summary>
+        /// The type (typically interface) which this scoped service implements
+        /// </summary>
+        public Type? ImplementsType { get; set; }
+
+        /// <summary>
         /// If supplied, the service will be registered as a keyed service
         /// </summary>
         public string Key { get; set; } = string.Empty;

--- a/DJT.Vertical/Attributes/TransientServiceAttribute.cs
+++ b/DJT.Vertical/Attributes/TransientServiceAttribute.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace DJT.Vertical.Attributes
+﻿namespace DJT.Vertical.Attributes
 {
     /// <summary>
     /// Register the class with the DI as a transient service,

--- a/DJT.Vertical/DJT.Vertical.csproj
+++ b/DJT.Vertical/DJT.Vertical.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>8.3.0</Version>
+    <Version>8.3.1</Version>
     <Authors>Daniel James Thorne</Authors>
     <Company>DJT Software</Company>
     <Description>Helpful components for building applications (particularly Web APIs) with vertical slice architecture. </Description>

--- a/DJT.Vertical/DJT.Vertical.csproj
+++ b/DJT.Vertical/DJT.Vertical.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>8.2.0</Version>
+    <Version>8.3.0</Version>
     <Authors>Daniel James Thorne</Authors>
     <Company>DJT Software</Company>
     <Description>Helpful components for building applications (particularly Web APIs) with vertical slice architecture. </Description>

--- a/DJT.Vertical/Exceptions/ConflictException.cs
+++ b/DJT.Vertical/Exceptions/ConflictException.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace DJT.Vertical.Exceptions
+﻿namespace DJT.Vertical.Exceptions
 {
     /// <summary>
     /// Provides a 409 status response, indicating Conflict.

--- a/DJT.Vertical/Exceptions/CustomStatusException.cs
+++ b/DJT.Vertical/Exceptions/CustomStatusException.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace DJT.Vertical.Exceptions
+﻿namespace DJT.Vertical.Exceptions
 {
     /// <summary>
     /// Provide a custom status code

--- a/DJT.Vertical/Exceptions/ForbiddenException.cs
+++ b/DJT.Vertical/Exceptions/ForbiddenException.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace DJT.Vertical.Exceptions
+﻿namespace DJT.Vertical.Exceptions
 {
     /// <summary>
     /// Provides a 403 Forbidden status result.

--- a/DJT.Vertical/Exceptions/NotFoundException.cs
+++ b/DJT.Vertical/Exceptions/NotFoundException.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace DJT.Vertical.Exceptions
+﻿namespace DJT.Vertical.Exceptions
 {
     /// <summary>
     /// Provides a 404 Not Found status for the request.

--- a/DJT.Vertical/Exceptions/PaymentRequiredException.cs
+++ b/DJT.Vertical/Exceptions/PaymentRequiredException.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace DJT.Vertical.Exceptions
+﻿namespace DJT.Vertical.Exceptions
 {
     /// <summary>
     /// Indicates a 402 status code response for the request.

--- a/DJT.Vertical/Http/AuthService.cs
+++ b/DJT.Vertical/Http/AuthService.cs
@@ -1,10 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Security.Claims;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DJT.Vertical.Http
 {

--- a/DJT.Vertical/Http/ClientErrorMiddleware.cs
+++ b/DJT.Vertical/Http/ClientErrorMiddleware.cs
@@ -1,11 +1,6 @@
 ﻿using DJT.Vertical.Exceptions;
 using Microsoft.AspNetCore.Http;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DJT.Vertical.Http
 {

--- a/DJT.Vertical/Http/ServiceExtensions.cs
+++ b/DJT.Vertical/Http/ServiceExtensions.cs
@@ -40,11 +40,11 @@ namespace DJT.Vertical.Http
                     {
                         if (t.Key != string.Empty)
                         {
-                            services.TryAddKeyedTransient(type, t.Key, t.ImplementsType);
+                            services.TryAddKeyedTransient(t.ImplementsType, t.Key, type);
                         }
                         else
                         {
-                            services.TryAddTransient(type, t.ImplementsType);
+                            services.TryAddTransient(t.ImplementsType, type);
                         }
                     }
                     else
@@ -74,7 +74,7 @@ namespace DJT.Vertical.Http
                         }
                         else
                         {
-                            services.TryAddScoped(s.ImplementsType, s.ImplementsType);
+                            services.TryAddScoped(s.ImplementsType, type);
                         }
                     }
                     else
@@ -98,11 +98,11 @@ namespace DJT.Vertical.Http
                     {
                         if (z.Key != string.Empty)
                         {
-                            services.TryAddKeyedSingleton(type, z.Key, z.ImplementsType);
+                            services.TryAddKeyedSingleton(z.ImplementsType, z.Key, type);
                         }
                         else
                         {
-                            services.TryAddSingleton(type, z.ImplementsType);
+                            services.TryAddSingleton(z.ImplementsType, type);
                         }
                     }
                     else

--- a/DJT.Vertical/Http/ServiceExtensions.cs
+++ b/DJT.Vertical/Http/ServiceExtensions.cs
@@ -37,14 +37,29 @@ namespace DJT.Vertical.Http
 
                 if (t is not null)
                 {
-                    if (t.Key != string.Empty)
+                    if (t.ImplementsType is not null)
                     {
-                        services.TryAddKeyedTransient(type, t.Key);
+                        if (t.Key != string.Empty)
+                        {
+                            services.TryAddKeyedTransient(type, t.Key, t.ImplementsType);
+                        }
+                        else
+                        {
+                            services.TryAddTransient(type, t.ImplementsType);
+                        }
                     }
                     else
                     {
-                        services.TryAddTransient(type);
+                        if (t.Key != string.Empty)
+                        {
+                            services.TryAddKeyedTransient(type, t.Key);
+                        }
+                        else
+                        {
+                            services.TryAddTransient(type);
+                        }
                     }
+
                 }
 
                 //scoped
@@ -52,13 +67,27 @@ namespace DJT.Vertical.Http
 
                 if (s is not null)
                 {
-                    if (s.Key != string.Empty)
+                    if (s.ImplementsType is not null)
                     {
-                        services.TryAddKeyedScoped(type, s.Key);
+                        if (s.Key  != string.Empty)
+                        {
+                            services.TryAddKeyedScoped(s.ImplementsType, s.Key, type);
+                        }
+                        else
+                        {
+                            services.TryAddScoped(s.ImplementsType, s.ImplementsType);
+                        }
                     }
                     else
                     {
-                        services.TryAddScoped(type);
+                        if (s.Key != string.Empty)
+                        {
+                            services.TryAddKeyedScoped(type, s.Key);
+                        }
+                        else
+                        {
+                            services.TryAddScoped(type);
+                        }
                     }
                 }
 
@@ -66,13 +95,27 @@ namespace DJT.Vertical.Http
                 var z = type.GetCustomAttribute<SingletonServiceAttribute>();
                 if (z is not null)
                 {
-                    if (z.Key != string.Empty)
+                    if (z.ImplementsType is not null)
                     {
-                        services.TryAddKeyedSingleton(service: type, serviceKey: z.Key);
+                        if (z.Key != string.Empty)
+                        {
+                            services.TryAddKeyedSingleton(type, z.Key, z.ImplementsType);
+                        }
+                        else
+                        {
+                            services.TryAddSingleton(type, z.ImplementsType);
+                        }
                     }
                     else
                     {
-                        services.TryAddSingleton(type);
+                        if (z.Key != string.Empty)
+                        {
+                            services.TryAddKeyedSingleton(service: type, serviceKey: z.Key);
+                        }
+                        else
+                        {
+                            services.TryAddSingleton(type);
+                        }
                     }
                 }
 

--- a/DJT.Vertical/Http/ServiceExtensions.cs
+++ b/DJT.Vertical/Http/ServiceExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using DJT.Vertical.Attributes;
-using DJT.Vertical.Interfaces;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/DJT.Vertical/Interfaces/AsyncRequestHandler.cs
+++ b/DJT.Vertical/Interfaces/AsyncRequestHandler.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace DJT.Vertical.Interfaces
+﻿namespace DJT.Vertical.Interfaces
 {
     /// <summary>
     /// Async implementation of <see cref="IRequestHandler{TResult}"/>

--- a/DJT.Vertical/Interfaces/IRequestHandler.cs
+++ b/DJT.Vertical/Interfaces/IRequestHandler.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace DJT.Vertical.Interfaces
+﻿namespace DJT.Vertical.Interfaces
 {
     /// <summary>
     /// A request handler which takes no arguments but provides a response.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ using the lifetime-named attributes.  Each attribute also allows an optional key
 the class as a keyed service.  For example:
 
 ```c#
-[SingletonService(Key = "for_science")]
-public class MySingletonService
+[SingletonService(ImplementsType = typeof(IMyInterface),Key = "for_science")]
+public class MySingletonService : IMyInterface
 {
 	public void DoSomething() 
 	{
@@ -32,7 +32,7 @@ public class MySingletonService
 }
 
 [ScopedService]
-public class MyScopedService ([FromKeyedServices("for_science")] MySingletonService singleton)
+public class MyScopedService ([FromKeyedServices("for_science")] IMyInterface singleton)
 {
 	public void DoSomethingElse()
 	{


### PR DESCRIPTION
Adds interface specification in the `TransientServiceAttribute`, `ScopedServiceAttribute` and `SingletonServiceAttribute`.  

This can be specified in the constructor along with a string key: `TransientServiceAttribute(IMyInterface, "my_key")`.

Previously keys did not make sense without specifying the implemented interface as each type is only registered with the DI once.