### PR TITLE
Added catch to web api middleware for NotFoundException

### DIFF
--- a/DJT.Vertical/Http/ClientErrorMiddleware.cs
+++ b/DJT.Vertical/Http/ClientErrorMiddleware.cs
@@ -22,6 +22,10 @@ namespace DJT.Vertical.Http
             {
                 await next(context);
             }
+            catch (NotFoundException ex)
+            {
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+            }
             catch (BadRequestException ex)
             {
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;


### PR DESCRIPTION
Responses of HTTP 500 were given for `NotFoundException`.  A correcting `catch` block was added to return HTTP 404.