### PR TITLE
Keyed service keys are type `object?`

### DIFF
--- a/DJT.Vertical/Attributes/ScopedServiceAttribute.cs
+++ b/DJT.Vertical/Attributes/ScopedServiceAttribute.cs
@@ -17,7 +17,7 @@
         /// </summary>
         /// <param name="implements">The type which the decorated class implements</param>
         /// <param name="key">The keyed type</param>
-        public ScopedServiceAttribute(Type implements, string key = "")
+        public ScopedServiceAttribute(Type implements, object? key = null)
         {
             ImplementsType = implements;
             Key = key;
@@ -31,6 +31,6 @@
         /// <summary>
         /// If supplied, the service will be registered as a keyed service
         /// </summary>
-        public object? Key { get; set; } = string.Empty;
+        public object? Key { get; set; } = null;
     }
 }

--- a/DJT.Vertical/Attributes/ScopedServiceAttribute.cs
+++ b/DJT.Vertical/Attributes/ScopedServiceAttribute.cs
@@ -31,6 +31,6 @@
         /// <summary>
         /// If supplied, the service will be registered as a keyed service
         /// </summary>
-        public string Key { get; set; } = string.Empty;
+        public object? Key { get; set; } = string.Empty;
     }
 }

--- a/DJT.Vertical/Attributes/SingletonServiceAttribute.cs
+++ b/DJT.Vertical/Attributes/SingletonServiceAttribute.cs
@@ -19,7 +19,7 @@
         /// </summary>
         /// <param name="implements"></param>
         /// <param name="key"></param>
-        public SingletonServiceAttribute(Type implements, string key = "")
+        public SingletonServiceAttribute(Type implements, object? key = null)
         {
             ImplementsType = implements;
             Key = key;
@@ -33,6 +33,6 @@
         /// <summary>
         /// If supplied, the service will be registered as a keyed service
         /// </summary>
-        public object? Key { get; set; } = string.Empty;
+        public object? Key { get; set; } = null;
     }
 }

--- a/DJT.Vertical/Attributes/SingletonServiceAttribute.cs
+++ b/DJT.Vertical/Attributes/SingletonServiceAttribute.cs
@@ -33,6 +33,6 @@
         /// <summary>
         /// If supplied, the service will be registered as a keyed service
         /// </summary>
-        public string Key { get; set; } = string.Empty;
+        public object? Key { get; set; } = string.Empty;
     }
 }

--- a/DJT.Vertical/Attributes/TransientServiceAttribute.cs
+++ b/DJT.Vertical/Attributes/TransientServiceAttribute.cs
@@ -20,7 +20,7 @@
         /// </summary>
         /// <param name="implements">The type the class implements.</param>
         /// <param name="key">If provided, the keyed service</param>
-        public TransientServiceAttribute(Type implements, string key = "")
+        public TransientServiceAttribute(Type implements, object? key = null)
         {
             ImplementsType = implements;
             Key = key;
@@ -34,6 +34,6 @@
         /// <summary>
         /// If supplied, the service will be registered as a keyed service
         /// </summary>
-        public object? Key { get; set; } = string.Empty;
+        public object? Key { get; set; } = null;
     }
 }

--- a/DJT.Vertical/Attributes/TransientServiceAttribute.cs
+++ b/DJT.Vertical/Attributes/TransientServiceAttribute.cs
@@ -34,6 +34,6 @@
         /// <summary>
         /// If supplied, the service will be registered as a keyed service
         /// </summary>
-        public string Key { get; set; } = string.Empty;
+        public object? Key { get; set; } = string.Empty;
     }
 }

--- a/DJT.Vertical/DJT.Vertical.csproj
+++ b/DJT.Vertical/DJT.Vertical.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>8.3.2</Version>
+    <Version>8.4.0</Version>
     <Authors>Daniel James Thorne</Authors>
     <Company>DJT Software</Company>
     <Description>Helpful components for building applications (particularly Web APIs) with vertical slice architecture. </Description>

--- a/DJT.Vertical/DJT.Vertical.csproj
+++ b/DJT.Vertical/DJT.Vertical.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Version>8.4.0</Version>
+    <Version>8.4.1</Version>
     <Authors>Daniel James Thorne</Authors>
     <Company>DJT Software</Company>
     <Description>Helpful components for building applications (particularly Web APIs) with vertical slice architecture. </Description>

--- a/DJT.Vertical/Http/ServiceExtensions.cs
+++ b/DJT.Vertical/Http/ServiceExtensions.cs
@@ -38,7 +38,7 @@ namespace DJT.Vertical.Http
                 {
                     if (t.ImplementsType is not null)
                     {
-                        if (t.Key != string.Empty)
+                        if (t.Key != null)
                         {
                             services.TryAddKeyedTransient(t.ImplementsType, t.Key, type);
                         }
@@ -49,7 +49,7 @@ namespace DJT.Vertical.Http
                     }
                     else
                     {
-                        if (t.Key != string.Empty)
+                        if (t.Key != null)
                         {
                             services.TryAddKeyedTransient(type, t.Key);
                         }
@@ -68,7 +68,7 @@ namespace DJT.Vertical.Http
                 {
                     if (s.ImplementsType is not null)
                     {
-                        if (s.Key  != string.Empty)
+                        if (s.Key  != null)
                         {
                             services.TryAddKeyedScoped(s.ImplementsType, s.Key, type);
                         }
@@ -79,7 +79,7 @@ namespace DJT.Vertical.Http
                     }
                     else
                     {
-                        if (s.Key != string.Empty)
+                        if (s.Key != null)
                         {
                             services.TryAddKeyedScoped(type, s.Key);
                         }
@@ -96,7 +96,7 @@ namespace DJT.Vertical.Http
                 {
                     if (z.ImplementsType is not null)
                     {
-                        if (z.Key != string.Empty)
+                        if (z.Key != null)
                         {
                             services.TryAddKeyedSingleton(z.ImplementsType, z.Key, type);
                         }
@@ -107,7 +107,7 @@ namespace DJT.Vertical.Http
                     }
                     else
                     {
-                        if (z.Key != string.Empty)
+                        if (z.Key != null)
                         {
                             services.TryAddKeyedSingleton(service: type, serviceKey: z.Key);
                         }


### PR DESCRIPTION
Changes the type of keys for keyed services from `string` to `object?`, which is as dotnet supports and will now allow using enums and numbers for keys.