### PR TITLE
Http split (v8.5)

### DIFF
--- a/DJT.Vertical.AspNetCore/AuthService.cs
+++ b/DJT.Vertical.AspNetCore/AuthService.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
 
-namespace DJT.Vertical.Http
+namespace DJT.Vertical.AspNetCore
 {
     /// <summary>
     /// Relies on the implementation of System.Security.Claims to allow dependency injection of 

--- a/DJT.Vertical.AspNetCore/ClientErrorMiddleware.cs
+++ b/DJT.Vertical.AspNetCore/ClientErrorMiddleware.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Http;
 using System.ComponentModel.DataAnnotations;
 
-namespace DJT.Vertical.Http
+namespace DJT.Vertical.AspNetCore
 {
     /// <summary>
     /// Catches exceptions provided in DJT.Vertical.Exceptions and the ValidationException.

--- a/DJT.Vertical.AspNetCore/DJT.Vertical.AspNetCore.csproj
+++ b/DJT.Vertical.AspNetCore/DJT.Vertical.AspNetCore.csproj
@@ -4,28 +4,23 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <Version>8.5.0</Version>
     <Authors>Daniel James Thorne</Authors>
     <Company>DJT Software</Company>
-    <Description>Helpful components for building applications (particularly Web APIs) with vertical slice architecture. </Description>
+    <Description>Helpful components for AspNetCore applications (particularly Web APIs) with vertical slice architecture. </Description>
     <Copyright>Daniel James Thorne</Copyright>
     <PackageTags>vertical slice;architecture;web api</PackageTags>
     <RepositoryUrl>https://github.com/rombethor/djt.vertical</RepositoryUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\DJT.Vertical\DJT.Vertical.csproj" />
+  </ItemGroup>
+  
 </Project>

--- a/DJT.Vertical.AspNetCore/DJT.Vertical.AspNetCore.csproj
+++ b/DJT.Vertical.AspNetCore/DJT.Vertical.AspNetCore.csproj
@@ -13,10 +13,18 @@
     <RepositoryUrl>https://github.com/rombethor/djt.vertical</RepositoryUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/DJT.Vertical.AspNetCore/HttpServiceExtensions.cs
+++ b/DJT.Vertical.AspNetCore/HttpServiceExtensions.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace DJT.Vertical.AspNetCore
+{
+    public static class HttpServiceExtensions
+    {
+
+        public static void AddVerticalHttpComponents(this IServiceCollection services)
+        {
+            services.AddVerticalComponents();
+
+            services.TryAddScoped<AuthService>();
+        }
+
+        /// <summary>
+        /// Adds client error handling middleware for web api
+        /// </summary>
+        /// <param name="app"></param>
+        public static void UseVerticalHttpComponents(this IApplicationBuilder app)
+        {
+            app.UseMiddleware<ClientErrorMiddleware>();
+        }
+    }
+}

--- a/DJT.Vertical.sln
+++ b/DJT.Vertical.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DJT.Vertical.AspNetCore", "DJT.Vertical.AspNetCore\DJT.Vertical.AspNetCore.csproj", "{55620863-E63C-4912-9E5E-43EC3A807A34}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +22,10 @@ Global
 		{A7E5019F-E7D0-49CD-BCD4-FE554AFDAE0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A7E5019F-E7D0-49CD-BCD4-FE554AFDAE0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A7E5019F-E7D0-49CD-BCD4-FE554AFDAE0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55620863-E63C-4912-9E5E-43EC3A807A34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{55620863-E63C-4912-9E5E-43EC3A807A34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{55620863-E63C-4912-9E5E-43EC3A807A34}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{55620863-E63C-4912-9E5E-43EC3A807A34}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DJT.Vertical/ServiceExtensions.cs
+++ b/DJT.Vertical/ServiceExtensions.cs
@@ -1,10 +1,9 @@
 ﻿using DJT.Vertical.Attributes;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System.Reflection;
 
-namespace DJT.Vertical.Http
+namespace DJT.Vertical
 {
     /// <summary>
     /// Extension methods for using the components in this library
@@ -12,15 +11,14 @@ namespace DJT.Vertical.Http
     public static class ServiceExtensions
     {
         /// <summary>
-        /// Adds generic AuthService dependency and registers IRequestHandlers in the calling assembly
+        /// Registers IRequestHandler implementations and services with the <see cref="ScopedServiceAttribute"/>, <see cref="SingletonServiceAttribute"/> 
+        /// and <see cref="TransientServiceAttribute"/> attributes with the DI container.
         /// </summary>
         /// <param name="services"></param>
         public static void AddVerticalComponents(this IServiceCollection services)
         {
-            services.TryAddScoped<AuthService>();
-
             var allTypes = Assembly.GetCallingAssembly().GetTypes();
-            foreach(var type in allTypes)
+            foreach (var type in allTypes)
             {
                 //transient IRequestHandler
                 var i = type.GetInterface("IRequestHandler`1")
@@ -68,7 +66,7 @@ namespace DJT.Vertical.Http
                 {
                     if (s.ImplementsType is not null)
                     {
-                        if (s.Key  != null)
+                        if (s.Key != null)
                         {
                             services.TryAddKeyedScoped(s.ImplementsType, s.Key, type);
                         }
@@ -121,13 +119,6 @@ namespace DJT.Vertical.Http
             }
         }
 
-        /// <summary>
-        /// Adds client error handling middleware for web api
-        /// </summary>
-        /// <param name="app"></param>
-        public static void UseVerticalComponents(this IApplicationBuilder app)
-        {
-            app.UseMiddleware<ClientErrorMiddleware>();
-        }
+
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,26 +1,17 @@
 # DJT.Vertical
 
-Vertical Slice architecture for Web APIs is an alternative to using controllers.
+As of v8.5, DJT.Vertical is not restricted to Web APIs, but can be used in any .NET application.  For Web APIs, there is an additional library: DJT.Vertical.AspNetCore
 
-## Using components
-
-In your web application, include `using DJT.Vertical.Http` and call the following:
-
-```c#
-
-builder.Services.AddVerticalComponents();
-
-var app = builder.Build();
-
-app.UseVerticalComponents();
-
-```
+This library consists of tools dependency injection and error handling across 'verticals'.
 
 ## Service Attributes
 
+I assume you know all about Dependency Injection in .NET, so I won't go into detail about that.  However, DJT.Vertical provides a set of attributes to make it easier to register services with dependency injection.
+
 Include the `DJT.Vertical.Attributes` namespace and start registering your dependency injected classes
 using the lifetime-named attributes.  Each attribute also allows an optional key to be defined, therefore registering
-the class as a keyed service.  For example:
+the class as a keyed service.  The `ImplementsType` interface (or base type) can also be specified in the attribute
+constructor.  For example:
 
 ```c#
 [SingletonService(ImplementsType = typeof(IMyInterface),Key = "for_science")]
@@ -44,9 +35,39 @@ public class MyScopedService ([FromKeyedServices("for_science")] IMyInterface si
 Similarly, there is also a `[TransientService]` attribute.
 
 > Note: It is the assembly which calls directly `AddVerticalComponents()` which will
-be scanned for these attributes.
+be scanned for these attributes (the 'Calling Assembly').
+
+## Registering services
+
+To register your attributed services, in your application, include `using DJT.Vertical` and call the following:
+
+```c#
+builder.Services.AddVerticalComponents();
+```
+
+For a custom DI container, you can use it like so:
+
+```c#
+ServiceCollection myServices = new ServiceCollection();
+myServices.AddVerticalComponents();
+```
+
+If you are using DJT.Vertical.AspNetCore, you can also include the following to use the components in your application:
+
+```c#
+builder.Services.AddVerticalHttpComponents();
+
+var app = builder.Build();
+
+app.UseVerticalHttpComponents();
+```
+
+This also adds the error handling middleware and auth service, discussed below, to the pipeline.
 
 ## Request Handlers
+
+This feature exists for creating a mediation layer for your Web API endpoints.  There is no mediation service defined in this library and there are no plans to add one yet.
+All implementations of the `IRequestHandler<>` interface will be automatically registered with dependency injection.
 
 Use the `IRequestHandler<>` interfaces to define the functionality of the API, using dependency injection
 for dependencies.  I.e.
@@ -61,18 +82,27 @@ public class GetEmployeesHandler(MyDbContext db) : IRequestHandler<IEnumerably<E
 }
 ```
 
-## Async
+### Async
 
-Included in v8.1 are abstract classes for `AsyncRequestHandler<>` which require a cancellation token and
-obligate the return value wrapped in a `Task<TRes>`.
+Added in v8.1 are abstract classes for `AsyncRequestHandler<>`.  These are just the same as the `IRequestHandler<>` interfaces, but with an `async` method signature.  Use these if you want to use `async`/`await` in your request handlers.
 
 ## Exceptions
+
+To avoid wrapping errors in bulky response wrappers which need to be passed down through the call stack, DJT.Vertical provides a set of exceptions which can be thrown from your request handlers.
+
+These exceptions will be caught by the middleware and converted into appropriate HTTP responses.  The `DJT.Vertical.AspNetCore` library includes middleware to handle these exceptions automatically.
 
 To return erroneous responses, use the included `Exception`s, such as `BadRequestException` for a HTTP 400
 response.
 
 Custom response codes can be supplied using `CustomStatusException`.
 
-## Auth Service
+> Future plans:
+> Responses in the next version will all derive from a `CustomStatusException` or similar, to make catching them easier.
+
+## Auth Service (DJT.Vertical.AspNetCore)
 
 A simple auth service for getting user claim information is included.
+
+> In future versions this may be expanded upon.
+


### PR DESCRIPTION
The AspNetCore framework was required by the library.  However, the DI components can be used in other scenarios such as tests and front-end apps.  I have separated out the parts which use AspNetCore into their own library (DJT.Vertical.AspNetCore), which depends upon the rest as its own library (same name).  

Beware, with this update there are breaking changes!  Namespaces have changed and the consumer may need to update which NuGet packages are included.